### PR TITLE
Show the slected option after the stars are selected.

### DIFF
--- a/jquery.rating.css
+++ b/jquery.rating.css
@@ -34,3 +34,10 @@
 .ui-rating-hover {
     background-position:left -48px;
 }
+
+.ui-selected-value {
+	background-color: #EEEEEE;
+	margin-left: 150px;
+	text-align: center;
+	width: 60px;
+}

--- a/jquery.rating.js
+++ b/jquery.rating.js
@@ -25,9 +25,9 @@
 			cancelValue: null,
 			cancelTitle: "Cancel",
 			startValue: null,
+			showTarget: false,
 			disabled: false
 		};
-
 
         //
         // Methods
@@ -95,6 +95,13 @@
 				if( !evt.data.hasChanged )
 				{
 					$(evt.data.selectBox).val( value ).trigger("change");
+					
+					// set uiVlaue
+					if (true == settings.showTarget) {
+						uiValue = $(evt.data.selectBox).find("option:selected").text();
+						targetId = "#" + evt.data.selectBox.attr("name");
+						$(targetId).text(uiValue);
+				    }
 				}
 			},
 			change: function(evt)
@@ -153,6 +160,14 @@
                 title: this.title,  // if there was a title, preserve it.
                 className: "ui-rating"
             }).insertAfter( self );
+			
+			// create the p to hold selected value
+		   if (true == settings.showTarget) {
+				uiValue = $("<p/>").prop({
+		         	id: this.name,  // set id to the input name attribute
+		         	className: "ui-selected-value"
+		    	}).insertAfter( elm );
+			}
             // create all of the stars
             $('option', self).each(function() {
                 // only convert options with a value


### PR DESCRIPTION
This adds a target p element populated with the currently selected rating. Provides additional user feedback. Set showTarget to true to enable this feature.

This requires the "name" attribute to be set on the select box. Maybe we can make it more generic? I had to do this to support multiple ratings on a single page, so I chose the "name" attribute to make the target unique. 
