### PR TITLE
Correctly count number of selected options

### DIFF
--- a/jquery.rating.js
+++ b/jquery.rating.js
@@ -189,7 +189,7 @@
             }
             // perserve the selected value
             //
-            if ( 0 !==  $('option:selected', self).size() ) {
+            if ( 0 !==  $('option[selected]', self).size() ) {
                 //methods.setValue(                
                 methods.setValue( self.val(), elm, self );
             } else {


### PR DESCRIPTION
":selected" always returns at least one element, because the browser automatically selects the first element.
Using "[selected]", only those elements that really have the "selected" attribute are returned.
