### PR TITLE
Fixed for jquery 1.9(.1)

### DIFF
--- a/jquery.rating.js
+++ b/jquery.rating.js
@@ -173,8 +173,8 @@
                 // only convert options with a value
 				if(this.value!="")
 				{
-                    $("<a/>").prop({
-                        className: "ui-rating-star ui-rating-empty",
+                    $("<a/>").attr({
+                        class: "ui-rating-star ui-rating-empty",
                         title: $(this).text(),   // perserve the option text as a title.
                         value: this.value        // perserve the value.
                     }).appendTo(elm);


### PR DESCRIPTION
Anchor elements were created with $.prop(), trying to set the 'value' attribute to store the relative value.  This was not possible, changing code to set attributes with $.attr(), this allows the value to be properly stored on the anchor tags representing the stars.
